### PR TITLE
docs: add development environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Ignore build artifacts and node modules
+build/
+node_modules/
+.pbw
+
+# Misc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Pebble Shopify Sales App
+
+This project contains a Pebble watch application that displays daily, weekly and monthly sales for a Shopify store using the Shopify GraphQL API.
+
+## Development Environment Setup
+
+Follow these steps to prepare your environment:
+
+### 1. Install prerequisites
+- Python 3
+- Node.js and npm
+- [uv](https://github.com/astral-sh/uv) for managing the Pebble CLI
+
+On Ubuntu for example:
+```bash
+sudo apt update
+sudo apt install -y python3 python3-venv python3-pip nodejs npm libsdl1.2debian libfdt1
+pip install uv
+```
+
+### 2. Install Pebble CLI and SDK
+```bash
+uv tool install pebble-tool
+pebble sdk install latest
+```
+
+### 3. Create and build a Pebble project
+```bash
+pebble new-project pebble-shop
+cd pebble-shop
+pebble build
+```
+
+### 4. Run the app on an emulator or device
+```bash
+# Emulator (Basalt as an example)
+pebble install --emulator basalt
+
+# Real watch
+pebble install --phone <phone-ip>
+```
+
+Refer to the [CoreDevices SDK documentation](https://github.com/coredevices/sdk-docs) for detailed usage and additional information.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Script to set up Pebble SDK development environment
+set -e
+
+# Install system prerequisites (example for Debian/Ubuntu)
+if command -v apt >/dev/null 2>&1; then
+  sudo apt update
+  sudo apt install -y python3 python3-venv python3-pip nodejs npm libsdl1.2debian libfdt1
+fi
+
+# Install uv and Pebble CLI
+echo "Installing uv and pebble-tool"
+pip install --user uv
+~/.local/bin/uv tool install pebble-tool
+
+# Install latest Pebble SDK
+~/.local/bin/pebble sdk install latest
+
+echo "Environment setup complete"


### PR DESCRIPTION
## Summary
- add README with instructions for installing Pebble SDK
- provide setup script to automate environment prerequisites
- ignore build artifacts and node modules

## Testing
- `bash -n scripts/setup.sh`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b7491ac950832ba763c14cb8a5c5e8